### PR TITLE
fix for handling of dropped replication packet

### DIFF
--- a/Chapter 8/RoboCatAction/RoboCatServer/Src/ReplicationManagerTransmissionData.cpp
+++ b/Chapter 8/RoboCatAction/RoboCatServer/Src/ReplicationManagerTransmissionData.cpp
@@ -84,7 +84,10 @@ void ReplicationManagerTransmissionData::HandleUpdateStateDeliveryFailure( int i
 					
 			for( const ReplicationTransmission& otherRT: rmtdp->mTransmissions )
 			{
-				inState &= ~otherRT.GetState();
+				if (otherRT.GetNetworkId() == inNetworkId) 
+				{
+					inState &= ~otherRT.GetState();
+				}
 			}
 		}
 		


### PR DESCRIPTION
In case of calculation of the new dirty state we should clear the mask only using objects with same network id in future packets.